### PR TITLE
[feat] Review 도메인 관련 기능 구현

### DIFF
--- a/Member/src/main/java/com/rainbowgon/member/domain/bookmark/controller/BookmarkController.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/bookmark/controller/BookmarkController.java
@@ -38,7 +38,8 @@ public class BookmarkController {
 
     /**
      * 홈 화면에서 보여지는 북마크 목록을 조회.
-     * 테마 ID, 테마 포스터, 제목, 지점명, 평균 별점, 리뷰 수 반환
+     * 회원의 전체 북마크 중 최신순 20개 반환
+     * -> 테마 ID, 테마 포스터, 제목, 지점명, 평균 별점, 리뷰 수
      */
     @GetMapping
     public ResponseEntity<ResponseWrapper<BookmarkSimpleResDto>> selectSimpleBookmarkList(
@@ -51,7 +52,8 @@ public class BookmarkController {
 
     /**
      * 마이페이지의 북마크 내역에서 보여지는 북마크 목록을 조회.
-     * 테마와 관련된 모든 정보 반환
+     * 회원의 전체 북마크 반환.
+     * -> 테마와 관련된 모든 데이터
      */
     @GetMapping("/detail")
     public ResponseEntity<ResponseWrapper<BookmarkDetailResDto>> selectDetailBookmarkList(

--- a/Member/src/main/java/com/rainbowgon/member/domain/bookmark/entity/EscapeStatus.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/bookmark/entity/EscapeStatus.java
@@ -1,0 +1,6 @@
+package com.rainbowgon.member.domain.bookmark.entity;
+
+public enum EscapeStatus {
+    SUCCESS,
+    FAIL,
+}

--- a/Member/src/main/java/com/rainbowgon/member/domain/bookmark/entity/SpoilStatus.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/bookmark/entity/SpoilStatus.java
@@ -1,0 +1,6 @@
+package com.rainbowgon.member.domain.bookmark.entity;
+
+public enum SpoilStatus {
+    YES,
+    NO,
+}

--- a/Member/src/main/java/com/rainbowgon/member/domain/bookmark/service/BookmarkServiceImpl.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/bookmark/service/BookmarkServiceImpl.java
@@ -48,6 +48,8 @@ public class BookmarkServiceImpl implements BookmarkService {
                                                           .build())
             );
         }
+
+        // TODO redis에 북마크 수 업데이트
     }
 
     @Override
@@ -57,6 +59,7 @@ public class BookmarkServiceImpl implements BookmarkService {
         Long profileId = getProfileId(memberId);
 
         // 요청 회원의 북마크 테마 목록 가져오기
+        // TODO 최신순으로 20개까지 자르기
         List<Bookmark> bookmarkList = bookmarkRepository.findAllByProfileId(profileId);
 
         // TODO 북마크 목록에서 테마 ID를 통해 각각의 테마 정보(아이디, 포스터, 테마명, 지점명) 가져오기 -> search-service
@@ -64,6 +67,7 @@ public class BookmarkServiceImpl implements BookmarkService {
         // TODO 북마크 목록에서 테마 ID를 통해 각각의 리뷰 정보(평균 별점, 리뷰 수) 가져오기 -> redis
 
 
+        // TODO pageInfo 추가
         return null;
     }
 
@@ -83,6 +87,7 @@ public class BookmarkServiceImpl implements BookmarkService {
         // TODO 북마크 목록에서 테마 ID를 통해 각각의 북마크 정보(북마크 수) 가져오기 -> redis
 
 
+        // TODO 무한스크롤
         return null;
     }
 

--- a/Member/src/main/java/com/rainbowgon/member/domain/member/controller/MemberController.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/member/controller/MemberController.java
@@ -53,20 +53,21 @@ public class MemberController {
     }
 
     /**
-     * 회원 정보 조회
-     * 회원 정보 수정 요청 시 보내줄 데이터
+     * 개인 정보 조회
+     * 개인 정보 수정 요청 시 보내줄 데이터
      */
     @GetMapping("/me")
     public ResponseEntity<ResponseWrapper<MemberInfoResDto>> selectMemberInfo(@AuthenticationPrincipal String memberId) {
 
         MemberInfoResDto memberInfoResDto = memberService.selectMemberInfo(UUID.fromString(memberId));
 
-        return JsonResponse.ok("회원 정보가 성공적으로 조회되었습니다.", memberInfoResDto);
+        return JsonResponse.ok("개인 정보가 성공적으로 조회되었습니다.", memberInfoResDto);
     }
 
     /**
-     * 회원 정보 수정
-     * 이름, 닉네임, 전화번호, 생년월일, 프로필사진
+     * 개인 정보 수정
+     * 수정 가능한 데이터 -> 이름, 닉네임, 전화번호, 생년월일, 프로필사진
+     * 이름은 수정 사항 없어도 기존값 그대로, 나머지는 수정 사항 없으면 null
      */
     @PatchMapping
     public ResponseEntity<ResponseWrapper<Nullable>> updateMemberInfo(
@@ -76,7 +77,7 @@ public class MemberController {
 
         memberService.updateMemberInfo(UUID.fromString(memberId), memberUpdateReqDto, profileImage);
 
-        return JsonResponse.ok("회원 정보가 성공적으로 수정되었습니다.");
+        return JsonResponse.ok("개인 정보가 성공적으로 수정되었습니다.");
     }
 
     /**

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/controller/ReviewController.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/controller/ReviewController.java
@@ -1,0 +1,14 @@
+package com.rainbowgon.member.domain.review.controller;
+
+import com.rainbowgon.member.domain.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reviews")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+}

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/controller/ReviewController.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/controller/ReviewController.java
@@ -1,9 +1,21 @@
 package com.rainbowgon.member.domain.review.controller;
 
+import com.rainbowgon.member.domain.review.dto.request.ReviewCreateReqDto;
+import com.rainbowgon.member.domain.review.dto.request.ReviewUpdateReqDto;
+import com.rainbowgon.member.domain.review.dto.response.MyReviewDetailResDto;
+import com.rainbowgon.member.domain.review.dto.response.ReviewDetailResDto;
+import com.rainbowgon.member.domain.review.dto.response.ThemeHistoryResDto;
 import com.rainbowgon.member.domain.review.service.ReviewService;
+import com.rainbowgon.member.global.response.JsonResponse;
+import com.rainbowgon.member.global.response.ResponseWrapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -11,4 +23,111 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReviewController {
 
     private final ReviewService reviewService;
+
+    /**
+     * 리뷰 작성
+     */
+    @PostMapping
+    public ResponseEntity<ResponseWrapper<MyReviewDetailResDto>> createReview(
+            @AuthenticationPrincipal String memberId,
+            @RequestBody ReviewCreateReqDto reviewCreateReqDto) {
+
+        MyReviewDetailResDto myReview = reviewService.createReview(UUID.fromString(memberId), reviewCreateReqDto);
+
+        return JsonResponse.ok("리뷰가 성공적으로 생성되었습니다.", myReview);
+    }
+
+    /**
+     * 리뷰 수정
+     * 수정 사항 있으면 변경된 값, 수정 사항 없어도 기존값 그대로 요청
+     */
+    @PatchMapping
+    public ResponseEntity<ResponseWrapper<MyReviewDetailResDto>> updateReview(
+            @AuthenticationPrincipal String memberId,
+            @RequestBody ReviewUpdateReqDto reviewUpdateReqDto) {
+
+        MyReviewDetailResDto myReview = reviewService.updateReview(UUID.fromString(memberId), reviewUpdateReqDto);
+
+        return JsonResponse.ok("리뷰가 성공적으로 수정되었습니다.", myReview);
+    }
+
+    /**
+     * 특정 테마의 리뷰 1건 조회 (비회원 테마 상세 페이지)
+     * 각 테마의 가장 최근 리뷰 1건 반환
+     * 리뷰가 없다면 null 반환
+     */
+    @GetMapping("/themes/one")
+    public ResponseEntity<ResponseWrapper<ReviewDetailResDto>> selectThemeReview(@RequestParam("themeId") Long themeId) {
+
+        ReviewDetailResDto review = reviewService.selectThemeReview(themeId);
+
+        if (review == null) {
+            return JsonResponse.ok("등록된 리뷰가 없습니다.", null);
+        }
+
+        return JsonResponse.ok("테마의 리뷰 1건이 성공적으로 조회되었습니다.", review);
+    }
+
+    /**
+     * 특정 테마의 리뷰 전체 조회 (회원 테마 상세 페이지)
+     */
+    @GetMapping("/themes/all")
+    public ResponseEntity<ResponseWrapper<List<ReviewDetailResDto>>> selectThemeReviewList(@RequestParam("themeId") Long themeId) {
+
+        List<ReviewDetailResDto> reviewList = reviewService.selectThemeReviewList(themeId);
+
+        return JsonResponse.ok("테마의 리뷰 목록이 성공적으로 조회되었습니다.", reviewList);
+    }
+
+    /**
+     * 특정 테마의 내가 쓴 리뷰 조회 (회원 테마 상세 페이지)
+     * 23.11.02 기준) 회원은 테마 1개 당 하나의 리뷰만 작성 가능 -> 조회 결과는 무조건 0개 또는 1개
+     */
+    @GetMapping("/themes/my")
+    public ResponseEntity<ResponseWrapper<MyReviewDetailResDto>> selectMyThemeReview(
+            @AuthenticationPrincipal String memberId,
+            @RequestParam("themeId") Long themeId) {
+
+        MyReviewDetailResDto myReview = reviewService.selectMyThemeReview(UUID.fromString(memberId), themeId);
+
+        return JsonResponse.ok("테마의 내가 쓴 리뷰가 성공적으로 조회되었습니다.", myReview);
+    }
+
+    /**
+     * 리뷰 삭제
+     */
+    @DeleteMapping("/{review-id}")
+    public ResponseEntity<ResponseWrapper<Nullable>> deleteReview(
+            @AuthenticationPrincipal String memberId,
+            @PathVariable("review-id") Long reviewId) {
+
+        reviewService.deleteReview(UUID.fromString(memberId), reviewId);
+
+        return JsonResponse.ok("리뷰가 성공적으로 삭제되었습니다.");
+    }
+
+    /**
+     * 내가 쓴 리뷰 전체 조회 (마이페이지)
+     */
+    @GetMapping("/my")
+    public ResponseEntity<ResponseWrapper<List<MyReviewDetailResDto>>> selectMyReviewList(
+            @AuthenticationPrincipal String memberId) {
+
+        List<MyReviewDetailResDto> myReviewList = reviewService.selectMyReviewList(UUID.fromString(memberId));
+
+        return JsonResponse.ok("내가 쓴 리뷰 목록이 성공적으로 조회되었습니다.", myReviewList);
+    }
+
+    /**
+     * 방탈출 기록 조회 (빌딩 페이지)
+     */
+    @GetMapping("/history/{profile-id}")
+    public ResponseEntity<ResponseWrapper<List<ThemeHistoryResDto>>> selectThemeHistory(
+            @PathVariable("profile-id") Long profileId) {
+
+        List<ThemeHistoryResDto> themeHistoryList = reviewService.selectThemeHistory(profileId);
+
+        return JsonResponse.ok("방탈출 히스토리가 성공적으로 조회되었습니다.", themeHistoryList);
+    }
+
 }

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/controller/ReviewController.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/controller/ReviewController.java
@@ -61,11 +61,7 @@ public class ReviewController {
 
         ReviewDetailResDto review = reviewService.selectThemeReview(themeId);
 
-        if (review == null) {
-            return JsonResponse.ok("등록된 리뷰가 없습니다.", null);
-        }
-
-        return JsonResponse.ok("테마의 리뷰 1건이 성공적으로 조회되었습니다.", review);
+        return JsonResponse.ok("테마의 리뷰가 성공적으로 조회되었습니다.", review);
     }
 
     /**
@@ -89,11 +85,7 @@ public class ReviewController {
             @RequestParam("themeId") Long themeId) {
 
         MyReviewDetailResDto myReview = reviewService.selectMyThemeReview(UUID.fromString(memberId), themeId);
-
-        if (myReview == null) {
-            return JsonResponse.ok("작성한 리뷰가 없습니다.", null);
-        }
-
+        
         return JsonResponse.ok("테마의 내가 쓴 리뷰가 성공적으로 조회되었습니다.", myReview);
     }
 

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/controller/ReviewController.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/controller/ReviewController.java
@@ -90,6 +90,10 @@ public class ReviewController {
 
         MyReviewDetailResDto myReview = reviewService.selectMyThemeReview(UUID.fromString(memberId), themeId);
 
+        if (myReview == null) {
+            return JsonResponse.ok("작성한 리뷰가 없습니다.", null);
+        }
+
         return JsonResponse.ok("테마의 내가 쓴 리뷰가 성공적으로 조회되었습니다.", myReview);
     }
 

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/dto/request/ReviewCreateReqDto.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/dto/request/ReviewCreateReqDto.java
@@ -1,0 +1,29 @@
+package com.rainbowgon.member.domain.review.dto.request;
+
+import com.rainbowgon.member.domain.bookmark.entity.EscapeStatus;
+import com.rainbowgon.member.domain.bookmark.entity.SpoilStatus;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewCreateReqDto {
+
+    private Long themeId;
+    private Double rating;
+    private EscapeStatus isEscaped;
+    private Integer myLevel;
+    private Integer hintCount;
+    private String content;
+    private SpoilStatus isSpoiler;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate performedDate;
+    @DateTimeFormat(pattern = "hh:mm")
+    private LocalTime performedTime;
+    private Integer performedHeadcount;
+}

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/dto/request/ReviewUpdateReqDto.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/dto/request/ReviewUpdateReqDto.java
@@ -1,0 +1,29 @@
+package com.rainbowgon.member.domain.review.dto.request;
+
+import com.rainbowgon.member.domain.bookmark.entity.EscapeStatus;
+import com.rainbowgon.member.domain.bookmark.entity.SpoilStatus;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewUpdateReqDto {
+
+    private Long reviewId;
+    private Double rating;
+    private EscapeStatus isEscape;
+    private Integer myLevel;
+    private Integer hintCount;
+    private String content;
+    private SpoilStatus isSpoiler;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate performedDate;
+    @DateTimeFormat(pattern = "hh:mm")
+    private LocalTime performedTime;
+    private Integer performedHeadcount;
+}

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/dto/response/MyReviewDetailResDto.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/dto/response/MyReviewDetailResDto.java
@@ -1,0 +1,42 @@
+package com.rainbowgon.member.domain.review.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.rainbowgon.member.domain.bookmark.entity.EscapeStatus;
+import com.rainbowgon.member.domain.review.entity.Review;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MyReviewDetailResDto { // 내가 작성한 리뷰 객체 (테마 상세페이지 용)
+
+    private Long reviewId;
+    private Double rating;
+    private EscapeStatus isEscaped;
+    private Integer myLevel;
+    private Integer hintCount;
+    private String content;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate performedDate;
+    @JsonFormat(pattern = "hh:mm")
+    private LocalTime performedTime;
+    private Integer performedHeadcount;
+
+    public static MyReviewDetailResDto from(Review review) {
+        return MyReviewDetailResDto.builder()
+                .reviewId(review.getId())
+                .rating(review.getRating())
+                .isEscaped(review.getIsEscaped())
+                .myLevel(review.getMyLevel())
+                .hintCount(review.getHintCount())
+                .content(review.getContent())
+                .performedDate(review.getPerformedDate())
+                .performedTime(review.getPerformedTime())
+                .performedHeadcount(review.getPerformedHeadcount())
+                .build();
+    }
+}

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/dto/response/ReviewDetailResDto.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/dto/response/ReviewDetailResDto.java
@@ -1,0 +1,44 @@
+package com.rainbowgon.member.domain.review.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.rainbowgon.member.domain.bookmark.entity.EscapeStatus;
+import com.rainbowgon.member.domain.review.entity.Review;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ReviewDetailResDto { // 다른 사람이 작성한 리뷰 객체 (테마 상세페이지 용)
+
+    private Long reviewId;
+    private Long profileId; // 다른 사람의 프로필 아이디
+    private Double rating;
+    private EscapeStatus isEscaped;
+    private Integer myLevel;
+    private Integer hintCount;
+    private String content;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate performedDate;
+    @JsonFormat(pattern = "hh:mm")
+    private LocalTime performedTime;
+    private Integer performedHeadcount;
+
+    public static ReviewDetailResDto from(Review review) {
+        return ReviewDetailResDto.builder()
+                .reviewId(review.getId())
+                .profileId(review.getProfileId())
+                .rating(review.getRating())
+                .isEscaped(review.getIsEscaped())
+                .myLevel(review.getMyLevel())
+                .hintCount(review.getHintCount())
+                .content(review.getContent())
+                .performedDate(review.getPerformedDate())
+                .performedTime(review.getPerformedTime())
+                .performedHeadcount(review.getPerformedHeadcount())
+                .build();
+    }
+}

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/dto/response/ThemeHistoryResDto.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/dto/response/ThemeHistoryResDto.java
@@ -1,0 +1,34 @@
+package com.rainbowgon.member.domain.review.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.rainbowgon.member.domain.bookmark.entity.EscapeStatus;
+import com.rainbowgon.member.domain.review.entity.Review;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ThemeHistoryResDto { // 내가 했던 방탈출 테마 객체
+
+    private Long themeId;
+    private String themePoster;
+    private String themeTitle;
+    private Double rating;
+    private EscapeStatus isEscaped; // 성공실패 여부
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate performedDate;
+
+    public static ThemeHistoryResDto of(Long themeId, String themePoster, String themeTitle, Review review) {
+        return ThemeHistoryResDto.builder()
+                .themeId(themeId)
+                .themePoster(themePoster)
+                .themeTitle(themeTitle)
+                .rating(review.getRating())
+                .isEscaped(review.getIsEscaped())
+                .performedDate(review.getPerformedDate())
+                .build();
+    }
+}

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/entity/Review.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/entity/Review.java
@@ -3,10 +3,14 @@ package com.rainbowgon.member.domain.review.entity;
 import com.rainbowgon.member.domain.bookmark.entity.EscapeStatus;
 import com.rainbowgon.member.domain.bookmark.entity.SpoilStatus;
 import com.rainbowgon.member.domain.profile.entity.Profile;
+import com.rainbowgon.member.domain.review.dto.request.ReviewUpdateReqDto;
 import com.rainbowgon.member.global.entity.BaseEntity;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -16,6 +20,8 @@ import java.time.LocalTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE Review SET is_valid = 'DELETED' WHERE review_id = ?")
+@Where(clause = "is_valid = 'VALID'")
 public class Review extends BaseEntity {
 
     @Id
@@ -38,9 +44,9 @@ public class Review extends BaseEntity {
     @Column(columnDefinition = "INT UNSIGNED")
     private Long reservationId;
 
-    @Column(columnDefinition = "FLOAT UNSIGNED")
+    @Column(columnDefinition = "DOUBLE UNSIGNED")
     @NotNull
-    private Float rating; // 0.0 ~ 5.0
+    private Double rating; // 0.0 ~ 5.0
 
     @Column(columnDefinition = "VARCHAR(10)")
     @Enumerated(EnumType.STRING)
@@ -65,5 +71,34 @@ public class Review extends BaseEntity {
     @Column(columnDefinition = "INT UNSIGNED")
     private Integer performedHeadcount;
 
+    @Builder
+    public Review(Long profileId, Long themeId, Long reservationId, Double rating, EscapeStatus isEscaped,
+                  Integer myLevel, Integer hintCount, String content, SpoilStatus isSpoiler,
+                  LocalDate performedDate, LocalTime performedTime, Integer performedHeadcount) {
+        this.profileId = profileId;
+        this.themeId = themeId;
+        this.reservationId = reservationId;
+        this.rating = rating;
+        this.isEscaped = isEscaped;
+        this.myLevel = myLevel;
+        this.hintCount = hintCount;
+        this.content = content;
+        this.isSpoiler = isSpoiler;
+        this.performedDate = performedDate;
+        this.performedTime = performedTime;
+        this.performedHeadcount = performedHeadcount;
+    }
+
+    public void updateReview(ReviewUpdateReqDto reviewUpdateReqDto) {
+        this.rating = reviewUpdateReqDto.getRating();
+        this.isEscaped = reviewUpdateReqDto.getIsEscape();
+        this.myLevel = reviewUpdateReqDto.getMyLevel();
+        this.hintCount = reviewUpdateReqDto.getHintCount();
+        this.content = reviewUpdateReqDto.getContent();
+        this.isSpoiler = reviewUpdateReqDto.getIsSpoiler();
+        this.performedDate = reviewUpdateReqDto.getPerformedDate();
+        this.performedTime = reviewUpdateReqDto.getPerformedTime();
+        this.performedHeadcount = reviewUpdateReqDto.getPerformedHeadcount();
+    }
 
 }

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/entity/Review.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/entity/Review.java
@@ -1,0 +1,69 @@
+package com.rainbowgon.member.domain.review.entity;
+
+import com.rainbowgon.member.domain.bookmark.entity.EscapeStatus;
+import com.rainbowgon.member.domain.bookmark.entity.SpoilStatus;
+import com.rainbowgon.member.domain.profile.entity.Profile;
+import com.rainbowgon.member.global.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id", columnDefinition = "INT UNSIGNED")
+    private Long id;
+
+    @ManyToOne(targetEntity = Profile.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "profile_id", insertable = false, updatable = false)
+    private Profile profile;
+
+    @Column(name = "profile_id")
+    @NotNull
+    private Long profileId;
+
+    @Column(columnDefinition = "INT UNSIGNED")
+    @NotNull
+    private Long themeId;
+
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Long reservationId;
+
+    @Column(columnDefinition = "FLOAT UNSIGNED")
+    @NotNull
+    private Float rating; // 0.0 ~ 5.0
+
+    @Column(columnDefinition = "VARCHAR(10)")
+    @Enumerated(EnumType.STRING)
+    private EscapeStatus isEscaped;
+
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Integer myLevel; // 1 ~ 5
+
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Integer hintCount;
+
+    private String content;
+
+    @Column(columnDefinition = "VARCHAR(5) DEFAULT 'NO'")
+    @Enumerated(EnumType.STRING)
+    private SpoilStatus isSpoiler;
+
+    private LocalDate performedDate;
+
+    private LocalTime performedTime;
+
+    @Column(columnDefinition = "INT UNSIGNED")
+    private Integer performedHeadcount;
+
+
+}

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/repository/ReviewRepository.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.rainbowgon.member.domain.review.repository;
+
+import com.rainbowgon.member.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/repository/ReviewRepository.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/repository/ReviewRepository.java
@@ -3,5 +3,17 @@ package com.rainbowgon.member.domain.review.repository;
 import com.rainbowgon.member.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    Optional<Review> findTopByThemeIdOrderByCreatedAtDesc(Long themeId);
+
+    Optional<Review> findByThemeIdAndProfileId(Long themeId, Long profileId);
+
+    List<Review> findAllByThemeId(Long themeId);
+
+    List<Review> findAllByProfileId(Long profileId);
+
 }

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/service/ReviewService.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/service/ReviewService.java
@@ -1,5 +1,31 @@
 package com.rainbowgon.member.domain.review.service;
 
 
+import com.rainbowgon.member.domain.review.dto.request.ReviewCreateReqDto;
+import com.rainbowgon.member.domain.review.dto.request.ReviewUpdateReqDto;
+import com.rainbowgon.member.domain.review.dto.response.MyReviewDetailResDto;
+import com.rainbowgon.member.domain.review.dto.response.ReviewDetailResDto;
+import com.rainbowgon.member.domain.review.dto.response.ThemeHistoryResDto;
+
+import java.util.List;
+import java.util.UUID;
+
 public interface ReviewService {
+
+    MyReviewDetailResDto createReview(UUID memberId, ReviewCreateReqDto reviewCreateReqDto);
+
+    MyReviewDetailResDto updateReview(UUID memberId, ReviewUpdateReqDto reviewUpdateReqDto);
+
+    ReviewDetailResDto selectThemeReview(Long themeId);
+
+    List<ReviewDetailResDto> selectThemeReviewList(Long themeId);
+
+    MyReviewDetailResDto selectMyThemeReview(UUID memberId, Long themeId);
+
+    void deleteReview(UUID memberId, Long reviewId);
+
+    List<MyReviewDetailResDto> selectMyReviewList(UUID memberId);
+
+    List<ThemeHistoryResDto> selectThemeHistory(Long profileId);
+
 }

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/service/ReviewService.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/service/ReviewService.java
@@ -1,0 +1,5 @@
+package com.rainbowgon.member.domain.review.service;
+
+
+public interface ReviewService {
+}

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/service/ReviewServiceImpl.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/service/ReviewServiceImpl.java
@@ -1,9 +1,25 @@
 package com.rainbowgon.member.domain.review.service;
 
+import com.rainbowgon.member.domain.profile.dto.response.ProfileSimpleResDto;
+import com.rainbowgon.member.domain.profile.service.ProfileService;
+import com.rainbowgon.member.domain.review.dto.request.ReviewCreateReqDto;
+import com.rainbowgon.member.domain.review.dto.request.ReviewUpdateReqDto;
+import com.rainbowgon.member.domain.review.dto.response.MyReviewDetailResDto;
+import com.rainbowgon.member.domain.review.dto.response.ReviewDetailResDto;
+import com.rainbowgon.member.domain.review.dto.response.ThemeHistoryResDto;
+import com.rainbowgon.member.domain.review.entity.Review;
 import com.rainbowgon.member.domain.review.repository.ReviewRepository;
+import com.rainbowgon.member.global.error.exception.ReviewNotFoundException;
+import com.rainbowgon.member.global.error.exception.ReviewUnauthorizedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -11,4 +27,164 @@ import org.springframework.stereotype.Service;
 public class ReviewServiceImpl implements ReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final ProfileService profileService;
+
+    @Transactional
+    @Override
+    public MyReviewDetailResDto createReview(UUID memberId, ReviewCreateReqDto reviewCreateReqDto) {
+
+        // TODO 예약 내역이 있는 리뷰인지 확인 (인증 뱃지)
+        // 예약 내역 있으면, 예약 날짜/시간이랑 입력값이랑 비교?
+        Long reservationId = null;
+
+        // 요청 회원의 프로필 ID 가져오기
+        Long profileId = getProfileId(memberId);
+
+        // 리뷰 생성
+        Review review = reviewRepository.save(
+                Review.builder()
+                        .profileId(profileId)
+                        .themeId(reviewCreateReqDto.getThemeId())
+                        .reservationId(reservationId)
+                        .rating(reviewCreateReqDto.getRating())
+                        .isEscaped(reviewCreateReqDto.getIsEscaped())
+                        .myLevel(reviewCreateReqDto.getMyLevel())
+                        .hintCount(reviewCreateReqDto.getHintCount())
+                        .content(reviewCreateReqDto.getContent())
+                        .isSpoiler(reviewCreateReqDto.getIsSpoiler())
+                        .performedDate(reviewCreateReqDto.getPerformedDate())
+                        .performedTime(reviewCreateReqDto.getPerformedTime())
+                        .performedHeadcount(reviewCreateReqDto.getPerformedHeadcount())
+                        .build());
+
+        // TODO redis에 리뷰 수, 평균 별점 업데이트
+
+        return MyReviewDetailResDto.from(review);
+    }
+
+    @Transactional
+    @Override
+    public MyReviewDetailResDto updateReview(UUID memberId, ReviewUpdateReqDto reviewUpdateReqDto) {
+
+        // 리뷰 객체 가져오기
+        Review review =
+                reviewRepository.findById(reviewUpdateReqDto.getReviewId()).orElseThrow(ReviewNotFoundException::new);
+
+        // 유효한 요청인지 확인
+        checkValidAccess(getProfileId(memberId), review.getProfileId());
+
+        // 리뷰 업데이트
+        review.updateReview(reviewUpdateReqDto);
+
+        // TODO redis에 평균 별점 업데이트
+
+        return MyReviewDetailResDto.from(review);
+    }
+
+    @Override
+    public ReviewDetailResDto selectThemeReview(Long themeId) {
+
+        // 테마 ID로 리뷰 1건 조회
+        Optional<Review> review = reviewRepository.findTopByThemeIdOrderByCreatedAtDesc(themeId);
+
+        // 해당 테마에 리뷰가 1건도 없으면 null 반환
+        return review.map(ReviewDetailResDto::from).orElse(null);
+    }
+
+    @Override
+    public List<ReviewDetailResDto> selectThemeReviewList(Long themeId) {
+
+        // 테마 ID로 리뷰 전체 조회
+        List<Review> reviewList = reviewRepository.findAllByThemeId(themeId);
+
+        // TODO pageInfo, 무한스크롤
+
+        return null;
+    }
+
+    @Override
+    public MyReviewDetailResDto selectMyThemeReview(UUID memberId, Long themeId) {
+
+        // 요청 회원의 프로필 ID 가져오기
+        Long profileId = getProfileId(memberId);
+
+        // 테마 ID와 프로필 ID로 리뷰 조회
+        Optional<Review> review = reviewRepository.findByThemeIdAndProfileId(themeId, profileId);
+
+        // 해당 테마에 요청 회원이 작성한 리뷰가 없으면 null 반환
+        return review.map(MyReviewDetailResDto::from).orElse(null);
+    }
+
+    @Transactional
+    @Override
+    public void deleteReview(UUID memberId, Long reviewId) {
+
+        // 요청 회원의 프로필 ID 가져오기
+        Long profileId = getProfileId(memberId);
+
+        // 리뷰 객체 가져오기
+        Review review = reviewRepository.findById(reviewId).orElseThrow(ReviewNotFoundException::new);
+
+        // 유효한 요청인지 확인
+        checkValidAccess(getProfileId(memberId), review.getProfileId());
+
+        // 리뷰 삭제
+        reviewRepository.delete(review);
+
+        // TODO redis에 리뷰 수, 평균 별점 업데이트
+    }
+
+    @Override
+    public List<MyReviewDetailResDto> selectMyReviewList(UUID memberId) {
+
+        // 요청 회원의 프로필 ID 가져오기
+        Long profileId = getProfileId(memberId);
+
+        // 프로필 ID로 리뷰 목록 조회
+        List<Review> reviewList = reviewRepository.findAllByProfileId(profileId);
+
+        // TODO pageInfo, 무한스크롤
+
+        return reviewList.stream().map(MyReviewDetailResDto::from).collect(Collectors.toList());
+    }
+
+    /**
+     * 방탈출 내역 확인 경우의 수
+     * 1. 예약 내역이 있고, 리뷰도 있는 경우 -> 예약 서비스에서 확인 가능
+     * 2. 예약 내역이 있고, 리뷰는 없는 경우 -> 예약 서비스에서 확인 가능
+     * 3. 예약 내역이 없고, 리뷰는 있는 경우 -> 멤버 서비스에서 확인 가능(여기)
+     * 4. 예약 내역도 없고, 리뷰도 없는 경우 -> 우리 서비스에서 확인 불가
+     */
+    @Override
+    public List<ThemeHistoryResDto> selectThemeHistory(Long profileId) {
+
+        // TODO 프로필 ID로 예약 서버에서 데이터(예약 ID, 테마 ID) 가져오기
+        List<Long> themeIdList = null;
+
+        // 프로필 ID로 리뷰 목록 조회
+        List<Review> reviewList = reviewRepository.findAllByProfileId(profileId);
+
+        // 중복 제거 (1번 경우)
+
+        // TODO 테마 ID로 검색 서버에서 테마 데이터(포스터, 테마명) 가져오기
+
+        return null;
+    }
+
+    /**
+     * 회원 ID(uuid)로 프로필 아이디 조회
+     */
+    private Long getProfileId(UUID memberId) {
+        ProfileSimpleResDto profile = profileService.selectProfileByMember(memberId);
+        return profile.getProfileId();
+    }
+
+    /**
+     * 요청 회원의 프로필 ID와 리뷰의 프로필 ID가 같은지 확인
+     */
+    private void checkValidAccess(Long requestProfileId, Long reviewProfileId) {
+        if (!requestProfileId.equals(reviewProfileId)) {
+            throw ReviewUnauthorizedException.EXCEPTION;
+        }
+    }
 }

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/service/ReviewServiceImpl.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/service/ReviewServiceImpl.java
@@ -1,0 +1,14 @@
+package com.rainbowgon.member.domain.review.service;
+
+import com.rainbowgon.member.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService {
+
+    private final ReviewRepository reviewRepository;
+}

--- a/Member/src/main/java/com/rainbowgon/member/domain/review/service/ReviewServiceImpl.java
+++ b/Member/src/main/java/com/rainbowgon/member/domain/review/service/ReviewServiceImpl.java
@@ -99,7 +99,7 @@ public class ReviewServiceImpl implements ReviewService {
 
         // TODO pageInfo, 무한스크롤
 
-        return null;
+        return reviewList.stream().map(ReviewDetailResDto::from).collect(Collectors.toList());
     }
 
     @Override

--- a/Member/src/main/java/com/rainbowgon/member/global/config/SecurityConfigure.java
+++ b/Member/src/main/java/com/rainbowgon/member/global/config/SecurityConfigure.java
@@ -36,6 +36,7 @@ public class SecurityConfigure {
                 .authorizeRequests()
                 .antMatchers("/members/signup/**").permitAll()
                 .antMatchers("/members/login/**").permitAll()
+                .antMatchers("/reviews/themes/one/**").permitAll()
                 .anyRequest().authenticated();
 
         httpSecurity

--- a/Member/src/main/java/com/rainbowgon/member/global/error/errorCode/GlobalErrorCode.java
+++ b/Member/src/main/java/com/rainbowgon/member/global/error/errorCode/GlobalErrorCode.java
@@ -35,6 +35,10 @@ public enum GlobalErrorCode implements BaseErrorCode {
     BOOKMARK_NOT_FOUND(NOT_FOUND, "BOOKMARK-404-1", "해당 북마크를 찾을 수 없습니다."),
     BOOKMARK_UNAUTHORIZED(UNAUTHORIZED, "BOOKMARK-401-1", "해당 북마크에 접근 권한이 없습니다."),
 
+    /* Review */
+    REVIEW_NOT_FOUND(NOT_FOUND, "REVIEW-404-1", "해당 리뷰를 찾을 수 없습니다."),
+    REVIEW_UNAUTHORIZED(UNAUTHORIZED, "REVIEW-401-1", "해당 리뷰에 접근 권한이 없습니다."),
+
     CUSTOM_INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, "GLOBAL-500-1", "서버 오류. 관리자에게 문의 부탁드립니다.");
 
     private HttpStatus status;

--- a/Member/src/main/java/com/rainbowgon/member/global/error/exception/ReviewNotFoundException.java
+++ b/Member/src/main/java/com/rainbowgon/member/global/error/exception/ReviewNotFoundException.java
@@ -1,0 +1,12 @@
+package com.rainbowgon.member.global.error.exception;
+
+import com.rainbowgon.member.global.error.errorCode.GlobalErrorCode;
+
+public class ReviewNotFoundException extends CustomException {
+
+    public static final CustomException EXCEPTION = new ReviewNotFoundException();
+
+    public ReviewNotFoundException() {
+        super(GlobalErrorCode.REVIEW_NOT_FOUND);
+    }
+}

--- a/Member/src/main/java/com/rainbowgon/member/global/error/exception/ReviewUnauthorizedException.java
+++ b/Member/src/main/java/com/rainbowgon/member/global/error/exception/ReviewUnauthorizedException.java
@@ -1,0 +1,12 @@
+package com.rainbowgon.member.global.error.exception;
+
+import com.rainbowgon.member.global.error.errorCode.GlobalErrorCode;
+
+public class ReviewUnauthorizedException extends CustomException {
+
+    public static final CustomException EXCEPTION = new ReviewUnauthorizedException();
+
+    public ReviewUnauthorizedException() {
+        super(GlobalErrorCode.REVIEW_UNAUTHORIZED);
+    }
+}


### PR DESCRIPTION
## Work Description ✏️

- 리뷰 CRUD 구현하였습니다.
- 테마 상세 페이지에서 필요한 리뷰 단 건 조회, 리뷰 전체 조회, 회원이 작성한 리뷰 조회 기능 구현하였습니다.
- 빌딩 화면에서 필요한 방탈출 기록 조회 기능 구현하였습니다.
- search, reservation 서버에서 데이터 가져오는 부분은 비우고 구현하였습니다.
- 무한 스크롤을 위한 페이징 구현과 redis와 통신하는 부분은 비우고 구현하였습니다.
- 비워둔 부분은 이번주 내로 설정 완료한 후 구현할 예정입니다.

## Share 🤔

- 방탈출 기록 조회 api를 어떻게 효율적으로 짤 수 있을지 고민 중에 있습니다.

## Related issue 🛠

- Closes #58 
