### PR TITLE
[fix] EC2와 docker의 포트 번호 통일

### DIFF
--- a/apigateway-server/Dockerfile
+++ b/apigateway-server/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:11
 ARG JAR_FILE=build/libs/*-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-Dspring.profiles.active=prod","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/apigateway-server/scripts/start.sh
+++ b/apigateway-server/scripts/start.sh
@@ -7,5 +7,5 @@ JAR="$ROOT_PATH/app.jar"
 CONTAINER="app_container"
 IMAGE="app_image"
 
-docker build -t "$IMAGE" $ROOT_PATH
-docker run -dp 8080:8080 --name "$CONTAINER" "$IMAGE"
+docker build -t "$IMAGE" "$ROOT_PATH"
+docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"

--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:11
 ARG JAR_FILE=build/libs/*-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-Dspring.profiles.active=prod","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/config-server/scripts/start.sh
+++ b/config-server/scripts/start.sh
@@ -7,5 +7,5 @@ JAR="$ROOT_PATH/app.jar"
 CONTAINER="app_container"
 IMAGE="app_image"
 
-docker build -t "$IMAGE" $ROOT_PATH
-docker run -dp 8080:8080 --name "$CONTAINER" "$IMAGE"
+docker build -t "$IMAGE" "$ROOT_PATH"
+docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"

--- a/eureka-server/Dockerfile
+++ b/eureka-server/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:11
 ARG JAR_FILE=build/libs/*-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-Dspring.profiles.active=prod","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/eureka-server/scripts/start.sh
+++ b/eureka-server/scripts/start.sh
@@ -7,5 +7,5 @@ JAR="$ROOT_PATH/app.jar"
 CONTAINER="app_container"
 IMAGE="app_image"
 
-docker build -t "$IMAGE" $ROOT_PATH
-docker run -dp 8080:8080 --name "$CONTAINER" "$IMAGE"
+docker build -t "$IMAGE" "$ROOT_PATH"
+docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"

--- a/member-service/Dockerfile
+++ b/member-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:11
 ARG JAR_FILE=build/libs/*-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-Dspring.profiles.active=prod","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/member-service/scripts/start.sh
+++ b/member-service/scripts/start.sh
@@ -7,5 +7,5 @@ JAR="$ROOT_PATH/app.jar"
 CONTAINER="app_container"
 IMAGE="app_image"
 
-docker build -t "$IMAGE" $ROOT_PATH
-docker run -dp 8080:8080 --name "$CONTAINER" "$IMAGE"
+docker build -t "$IMAGE" "$ROOT_PATH"
+docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:11
 ARG JAR_FILE=build/libs/*-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-Dspring.profiles.active=prod","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/notification-service/scripts/start.sh
+++ b/notification-service/scripts/start.sh
@@ -7,5 +7,5 @@ JAR="$ROOT_PATH/app.jar"
 CONTAINER="app_container"
 IMAGE="app_image"
 
-docker build -t "$IMAGE" $ROOT_PATH
-docker run -dp 8080:8080 --name "$CONTAINER" "$IMAGE"
+docker build -t "$IMAGE" "$ROOT_PATH"
+docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"

--- a/reservation-service/Dockerfile
+++ b/reservation-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:11
 ARG JAR_FILE=build/libs/*-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-Dspring.profiles.active=prod","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/reservation-service/scripts/start.sh
+++ b/reservation-service/scripts/start.sh
@@ -7,5 +7,5 @@ JAR="$ROOT_PATH/app.jar"
 CONTAINER="app_container"
 IMAGE="app_image"
 
-docker build -t "$IMAGE" $ROOT_PATH
-docker run -dp 8080:8080 --name "$CONTAINER" "$IMAGE"
+docker build -t "$IMAGE" "$ROOT_PATH"
+docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"

--- a/search-service/Dockerfile
+++ b/search-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:11
 ARG JAR_FILE=build/libs/*-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-Dspring.profiles.active=prod","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/search-service/scripts/start.sh
+++ b/search-service/scripts/start.sh
@@ -7,5 +7,5 @@ JAR="$ROOT_PATH/app.jar"
 CONTAINER="app_container"
 IMAGE="app_image"
 
-docker build -t "$IMAGE" $ROOT_PATH
-docker run -dp 8080:8080 --name "$CONTAINER" "$IMAGE"
+docker build -t "$IMAGE" "$ROOT_PATH"
+docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"

--- a/sender-server/Dockerfile
+++ b/sender-server/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:11
 ARG JAR_FILE=build/libs/*-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-Dspring.profiles.active=prod","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/sender-server/scripts/start.sh
+++ b/sender-server/scripts/start.sh
@@ -7,5 +7,5 @@ JAR="$ROOT_PATH/app.jar"
 CONTAINER="app_container"
 IMAGE="app_image"
 
-docker build -t "$IMAGE" $ROOT_PATH
-docker run -dp 8080:8080 --name "$CONTAINER" "$IMAGE"
+docker build -t "$IMAGE" "$ROOT_PATH"
+docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"


### PR DESCRIPTION
## Work Description ✏️

- EC2와 docker의 포트 번호를 80번으로 통일했습니다.
- 참고로, rabbitmq의 경우, 5672번과 15672번으로 열었습니다.
- bootstrap.yml 파일에서 사용할 프로필을 선택하므로 Dockerfile에서 해당 내용을 제거했습니다.

## Share 🤔

## Related issue 🛠

- Closes #101
