### PR TITLE
[infra/fix] docker 실행 시 내부 포트를 80으로 수정

### DIFF
--- a/apigateway-server/scripts/start.sh
+++ b/apigateway-server/scripts/start.sh
@@ -8,4 +8,4 @@ CONTAINER="app_container"
 IMAGE="app_image"
 
 docker build -t "$IMAGE" "$ROOT_PATH"
-docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"
+docker run -dp 80:80 --name "$CONTAINER" "$IMAGE"

--- a/config-server/scripts/start.sh
+++ b/config-server/scripts/start.sh
@@ -8,4 +8,4 @@ CONTAINER="app_container"
 IMAGE="app_image"
 
 docker build -t "$IMAGE" "$ROOT_PATH"
-docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"
+docker run -dp 80:80 --name "$CONTAINER" "$IMAGE"

--- a/eureka-server/scripts/start.sh
+++ b/eureka-server/scripts/start.sh
@@ -8,4 +8,4 @@ CONTAINER="app_container"
 IMAGE="app_image"
 
 docker build -t "$IMAGE" "$ROOT_PATH"
-docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"
+docker run -dp 80:80 --name "$CONTAINER" "$IMAGE"

--- a/member-service/scripts/start.sh
+++ b/member-service/scripts/start.sh
@@ -8,4 +8,4 @@ CONTAINER="app_container"
 IMAGE="app_image"
 
 docker build -t "$IMAGE" "$ROOT_PATH"
-docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"
+docker run -dp 80:80 --name "$CONTAINER" "$IMAGE"

--- a/notification-service/scripts/start.sh
+++ b/notification-service/scripts/start.sh
@@ -8,4 +8,4 @@ CONTAINER="app_container"
 IMAGE="app_image"
 
 docker build -t "$IMAGE" "$ROOT_PATH"
-docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"
+docker run -dp 80:80 --name "$CONTAINER" "$IMAGE"

--- a/reservation-service/scripts/start.sh
+++ b/reservation-service/scripts/start.sh
@@ -8,4 +8,4 @@ CONTAINER="app_container"
 IMAGE="app_image"
 
 docker build -t "$IMAGE" "$ROOT_PATH"
-docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"
+docker run -dp 80:80 --name "$CONTAINER" "$IMAGE"

--- a/search-service/scripts/start.sh
+++ b/search-service/scripts/start.sh
@@ -8,4 +8,4 @@ CONTAINER="app_container"
 IMAGE="app_image"
 
 docker build -t "$IMAGE" "$ROOT_PATH"
-docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"
+docker run -dp 80:80 --name "$CONTAINER" "$IMAGE"

--- a/sender-server/scripts/start.sh
+++ b/sender-server/scripts/start.sh
@@ -8,4 +8,4 @@ CONTAINER="app_container"
 IMAGE="app_image"
 
 docker build -t "$IMAGE" "$ROOT_PATH"
-docker run -dp 80:8080 --name "$CONTAINER" "$IMAGE"
+docker run -dp 80:80 --name "$CONTAINER" "$IMAGE"


### PR DESCRIPTION
## Work Description ✏️

- docker 실행 시 내부 포트를 80으로 수정했습니다.
- 이제, docker의 외부 포트, 내부 포트, 어플리케이션의 포트 모두 80번으로 통합니다.

## Share 🤔

- 유레카 서버에서 각 인스턴스를 등록할 때 포트 번호를 도커의 포트 번호가 아닌 어플리케이션의 포트 번호를 등록하여 도커의 포트와 어플리케이션의 포트를 모두 통일하게 되었습니다.

## Related issue 🛠

- Closes #130 
