### PR TITLE
[fix] base entity의 created_at default값 수정

### DIFF
--- a/member-service/src/main/java/com/rainbowgon/memberservice/global/entity/BaseEntity.java
+++ b/member-service/src/main/java/com/rainbowgon/memberservice/global/entity/BaseEntity.java
@@ -1,7 +1,6 @@
 package com.rainbowgon.memberservice.global.entity;
 
 import lombok.Getter;
-import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -14,8 +13,7 @@ import java.time.LocalDateTime;
 public abstract class BaseEntity {
 
     @CreatedDate
-    @ColumnDefault("CURRENT_TIMESTAMP")
-    @Column(updatable = false)
+    @Column(updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## Work Description ✏️

- base entity의 created_at default 설정을 ColumnDefault가 아닌 columnDefinition으로 변경했습니다.

## Share 🤔


## Related issue 🛠

- Closes #216 
