### PR TITLE
[fix] 프로필 이미지 없을 경우 null 처리

### DIFF
--- a/member-service/src/main/java/com/rainbowgon/memberservice/domain/profile/service/ProfileServiceImpl.java
+++ b/member-service/src/main/java/com/rainbowgon/memberservice/domain/profile/service/ProfileServiceImpl.java
@@ -87,7 +87,10 @@ public class ProfileServiceImpl implements ProfileService {
         Profile profile = getProfileByMemberId(memberId);
 
         // 프로필 이미지 s3 url로 변경
-        String profileImageUrl = s3FileService.getS3Url(profile.getProfileImage());
+        String profileImageUrl = null;
+        if (profile.getProfileImage() != null) {
+            profileImageUrl = s3FileService.getS3Url(profile.getProfileImage());
+        }
 
         return ProfileSimpleResDto.from(profile, profileImageUrl);
     }


### PR DESCRIPTION
## Work Description ✏️

- DB에 저장된 프로필 이미지가 없을 경우 응답값에 null로 반환하도록 수정하였습니다.

## Share 🤔


## Related issue 🛠

- Closes #456 
