### PR TITLE
[feat] 예약 테스트시에 설정된 값 반환

### DIFF
--- a/reservation-service/src/main/java/com/rainbowgon/reservationservice/global/config/ConnectionConfig.java
+++ b/reservation-service/src/main/java/com/rainbowgon/reservationservice/global/config/ConnectionConfig.java
@@ -16,6 +16,9 @@ public class ConnectionConfig {
     @Value("${spring.reservation.on-off}")
     private String onOff;
 
+    @Value("${spring.reservation.off-return-value}")
+    private String offReturnValue;
+
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();

--- a/reservation-service/src/main/java/com/rainbowgon/reservationservice/global/connection/MasterkeyReservationAction.java
+++ b/reservation-service/src/main/java/com/rainbowgon/reservationservice/global/connection/MasterkeyReservationAction.java
@@ -16,10 +16,20 @@ public class MasterkeyReservationAction implements ReservationAction {
     private final ConnectionConfig config;
     private final RestTemplate restTemplate;
 
+    /**
+     * @return 실패인 경우, false 반환
+     * @return 성공인 경우, true 반환
+     */
     @Override
     public Boolean reserve(ReservingServerRequestDto reservingServerRequestDto) {
-        if (config.getOnOff().equalsIgnoreCase("OFF")) {
-            return false;
+        /*
+          config 파일에서 `on-off` 값이 `ON`인 경우에 실제 예약 동작함
+          그 외는 실제 동작을 하지 않음
+          `off-return-value`가 `SUCCESS`인 경우에 성공 테스트
+          `SUCCESS`가 아닌 그 외인 경우 실패 테스트
+         */
+        if (!config.getOnOff().equalsIgnoreCase("ON")) {
+            return config.getOffReturnValue().equalsIgnoreCase("SUCCESS");
         }
 
         String uri = getRequestUrl();


### PR DESCRIPTION
## Work Description ✏️

- 예약 테스트 시에 설정된 값을 반환합니다.
- Config 파일에서 설정할 수 있도록 했습니다.
- `on-off` 값이 `ON`인 경우에만 실제 예약 동작을 합니다. 그 외에는 실제 동작을 하지 않습니다.
- `on-off` 값이 `ON`이 아닌 경우, 즉 실제 동작을 하지 않는 경우, `off-return-value` 값이 `SUCCESS` 일 때 예약 성공을 반환합니다.
- `SUCCESS` 가 아닌 다른 값일 때에는 실패를 반환합니다.

## Share 🤔

## Related issue 🛠

- Closes #472
